### PR TITLE
Bind properties to allure.reports

### DIFF
--- a/src/main/java/ru/iopump/qa/allure/properties/AllureProperties.java
+++ b/src/main/java/ru/iopump/qa/allure/properties/AllureProperties.java
@@ -42,6 +42,7 @@ public class AllureProperties {
             this("allure/reports/", "reports/", 20);
         }
 
+        @ConstructorBinding
         public Reports(String dir,
                        String path,
                        long historyLevel) {


### PR DESCRIPTION
Without this, allure.reports uses the default values, as it binds to the empty constructor
