### PR TITLE
add oauth2 support

### DIFF
--- a/.helm/allure-server/values.yaml
+++ b/.helm/allure-server/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: kochetkovma/allure-server
   pullPolicy: IfNotPresent
   ## Don't use 'latest' ;)
-  tag: 2.11.2
+  tag: 2.12.0
 
 ## Add 'key: value collection' and delete '{ }' if need
 ## Uncomment and remove '{ }' if need

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY --from=build /home/gradle/build/libs/allure-server-docker.jar /allure-serve
 EXPOSE ${PORT:-8080}
 # Run application
 ENV JAVA_OPTS="-Xms256m -Xmx2048m"
-ENTRYPOINT ["java", "-Dloader.path=/ext", "-cp", "allure-server-docker.jar", "-Dspring.profiles.active=${PROFILE:default}", "org.springframework.boot.loader.PropertiesLauncher"]
+ENTRYPOINT ["java", "-Dloader.path=/ext", "-cp", "allure-server-docker.jar", "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE:default}", "org.springframework.boot.loader.PropertiesLauncher"]

--- a/README.md
+++ b/README.md
@@ -170,6 +170,53 @@ allure:
 - Report with path=`service/production-job` and age=`10d` will be removed at today MIDNIGHT
 - Report with path=`service/production-job` and age=`9d` will **NOT** be removed at today MIDNIGHT
 
+### OAuth2 feature (since 2.12.0)
+Separate Spring profile has been added `oauth`
+
+To enable `Oauth` add this profile to `SPRING_PROFILES_ACTIVE` . For example:
+- in `values.yaml` (Helm): 
+```yaml
+env:
+    SPRING_PROFILES_ACTIVE: oauth
+``` 
+- shell command `export SPRING_PROFILES_ACTIVE=oauth`
+- docker compose
+```yaml
+    environment:
+      SPRING_PROFILES_ACTIVE: oauth
+```
+
+Now [application-oauth.yaml](src/main/resources/application-oauth.yaml) is adjusted to use Google Auth Server:
+```yaml
+### Internal Spring Configuration
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${OAUTH2_GOOGLE_ALLURE_CLIENT_ID}
+            client-secret: ${OAUTH2_GOOGLE_ALLURE_CLIENT_SECRET}
+            scope: openid, profile, email
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            client-name: Google
+        provider:
+          google:
+            issuer-uri: https://accounts.google.com
+
+### App OAuth2 Security Configuration Toggle
+app:
+  security:
+    enable-oauth2: true
+```
+Pass your `OAUTH2_GOOGLE_ALLURE_CLIENT_ID` and `OAUTH2_GOOGLE_ALLURE_CLIENT_SECRET` or override configuration options to use other provider.
+
+There is Oauth feature-toggle `app.security.enable-oauth2`
+
+> Every spring boot setting can be passed through ENV variables with a little changes according to [spring boot cfg docs](https://docs.spring.io/spring-boot/docs/1.5.5.RELEASE/reference/html/boot-features-external-config.html)
+
+**By default `oauth` profile is not used and disabled**
+
 ### Special options
 
 > Since version `1.2.0` all reports manage with Database and have unic uuids.

--- a/docker-compose-h2.yml
+++ b/docker-compose-h2.yml
@@ -3,8 +3,11 @@ services:
   allure-server:
     # For local debug #
     # build: .
-    image: kochetkovma/allure-server:2.11.1
+    image: kochetkovma/allure-server:2.12.0
     ports:
       - 8080:8080
     volumes:
       - ./tmp/allure:/allure/:rw
+    environment:
+      SPRING_PROFILES_ACTIVE: oauth
+      # BASIC_AUTH_ENABLE: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   allure-server:
     # For local debug #
     # build: .
-    image: kochetkovma/allure-server:2.11.1
+    image: kochetkovma/allure-server:2.12.0
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/allure
       SPRING_DATASOURCE_USERNAME: postgres

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -31,6 +31,12 @@ dependencies {
     implementation "com.google.guava:guava:$guavaVersion"
     /* Open API */
     implementation "org.springdoc:springdoc-openapi-ui:$openApiVersion"
+
+    /* OAuth2 */
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-oauth2-client'
+    implementation 'org.springframework.security:spring-security-oauth2-jose'
+
     /* Spring Boot */
     implementation('org.springframework.boot:spring-boot-starter-web') { exclude group: 'ch.qos.logback' }
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/resources/application-oauth.yaml
+++ b/src/main/resources/application-oauth.yaml
@@ -1,0 +1,20 @@
+### Internal Spring Configuration
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${OAUTH2_GOOGLE_ALLURE_CLIENT_ID}
+            client-secret: ${OAUTH2_GOOGLE_ALLURE_CLIENT_SECRET}
+            scope: openid, profile, email
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            client-name: Google
+        provider:
+          google:
+            issuer-uri: https://accounts.google.com
+
+### App OAuth2 Security Configuration Toggle
+app:
+  security:
+    enable-oauth2: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,24 @@ spring:
     database: H2
     show-sql: false
     hibernate.ddl-auto: update
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${OAUTH2_GOOGLE_ALLURE_CLIENT_ID}
+            client-secret: ${OAUTH2_GOOGLE_ALLURE_CLIENT_SECRET}
+            scope: openid, profile, email
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            client-name: Google
+        provider:
+          google:
+            issuer-uri: https://accounts.google.com
+
+### App OAuth2 Security Configuration Toggle
+app:
+  security:
+    enable-oauth2: false
 
 vaadin.urlMapping: "/ui/*"
 server.port: ${PORT:8080}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,32 +16,16 @@ spring:
     database: H2
     show-sql: false
     hibernate.ddl-auto: update
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            client-id: ${OAUTH2_GOOGLE_ALLURE_CLIENT_ID}
-            client-secret: ${OAUTH2_GOOGLE_ALLURE_CLIENT_SECRET}
-            scope: openid, profile, email
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
-            client-name: Google
-        provider:
-          google:
-            issuer-uri: https://accounts.google.com
-
-### App OAuth2 Security Configuration Toggle
-app:
-  security:
-    enable-oauth2: false
 
 vaadin.urlMapping: "/ui/*"
 server.port: ${PORT:8080}
+
 ### Security
 basic.auth:
   username: admin
   password: admin
   enable: false
+
 ### App Configuration
 springdoc.swagger-ui.path: /swagger-ui.html
 


### PR DESCRIPTION
### Description
This PR introduces basic OAuth2 support to the project, enhancing the authentication system to allow users to authenticate using OAuth2 providers such as Google. By default, the `security.enable-oauth2` property is set to `false`, providing flexibility in choosing between OAuth2 and the previous default `HTTP_BASIC` authentication method.

### Changes Made
- Added OAuth2 configuration options to the `application.yaml` file.
- Enhanced the security configuration to support OAuth2 authentication.
- Introduced the `security.enable-oauth2` property for easy toggling of OAuth2 authentication.


### Testing done
- Just basic testing performed (basic http auth and OAuth2 auth) - code review required 🙏 