### PR TITLE
fix(deps): bump Spring Boot and Spring Cloud to clear five critical CVEs

### DIFF
--- a/.claude/convention/versions.md
+++ b/.claude/convention/versions.md
@@ -1,6 +1,6 @@
 # Pinned Versions — allure-server
 
-> SINGLE source of truth for every version number in this repo. != inline version literals in any other `.claude/**` doc — point here. != floating tags (`latest`, `+`, ranges). Verified against code 2026-06-11.
+> SINGLE source of truth for every version number in this repo. != inline version literals in any other `.claude/**` doc — point here. != floating tags (`latest`, `+`, ranges). Verified against code 2026-08-16 (release 3.0.1).
 
 ## Toolchain
 
@@ -15,7 +15,7 @@
 
 | Plugin | Version |
 |--------|---------|
-| `org.springframework.boot` | 3.4.13 |
+| `org.springframework.boot` | 3.5.16 |
 | `io.spring.dependency-management` | 1.1.7 |
 | `io.freefair.lombok` | 9.2.0 |
 | `com.github.ben-manes.versions` | 0.54.0 |
@@ -35,8 +35,17 @@
 
 | Item | Version | Why |
 |------|---------|-----|
-| Spring Cloud BOM (`ext.springCloudVersion`) | 2024.0.3 | Release train for Boot 3.4.x; Spring Cloud starters MUST be declared version-less |
-| Byte Buddy + agent (`ext.byteBuddyVersion`) | 1.17.5 | Boot 3.4 BOM pins 1.15.11 (Java 24 max); 1.17.5+ required for Java 25 class-file version 69 |
+| Spring Cloud BOM (`ext.springCloudVersion`) | 2025.0.3 | Release train for Boot 3.5.x (`spring-cloud-starter-parent:2025.0.3` -> `spring-boot-starter-parent:3.5.15`); Spring Cloud starters MUST be declared version-less |
+
+> Byte Buddy override removed in 3.0.1: the Boot 3.5.16 BOM pins 1.17.8, which already covers Java 25 class-file version 69. Re-add an override only if a future Boot train regresses below 1.17.5.
+
+Resolved via the BOMs above, tracked because 3.0.1 was a CVE patch release (verify with `./gradlew dependencyInsight --configuration runtimeClasspath --dependency <name>`):
+
+| Transitive | Resolved | CVE cleared |
+|------------|----------|-------------|
+| `org.apache.tomcat.embed:tomcat-embed-core` | 10.1.55 | CVE-2026-41293, CVE-2026-43512, CVE-2026-43515 |
+| `org.springframework.security:spring-security-web` | 6.5.11 | CVE-2026-22732 (needs >= 6.5.9, i.e. the Boot 3.5 train) |
+| `org.bouncycastle:bcprov-jdk18on` | 1.80.2 | CVE-2025-14813 (transitive via `spring-cloud-starter:4.3.3`) |
 
 ## Libraries (`gradle/dependencies.gradle`)
 
@@ -66,7 +75,7 @@ All other deps (Spring starters, security, JPA, hibernate-validator, h2, postgre
 
 | Image | Tag |
 |-------|-----|
-| `kochetkovma/allure-server` | 3.0.0 — pinned in `docker-compose.yml` / `docker-compose-h2.yml` (`image:` + `build.args.APP_VERSION`, both files carry an active `build: .`, so the tag names the locally built image) and in `.helm/allure-server/Chart.yaml` `appVersion` (helm `values.yaml` `image.tag` is intentionally empty and falls back to `.Chart.AppVersion`). Chart `version` tracks `appVersion` 1:1 |
+| `kochetkovma/allure-server` | 3.0.1 — pinned in `docker-compose.yml` / `docker-compose-h2.yml` (`image:` + `build.args.APP_VERSION`, both files carry an active `build: .`, so the tag names the locally built image) and in `.helm/allure-server/Chart.yaml` `appVersion` (helm `values.yaml` `image.tag` is intentionally empty and falls back to `.Chart.AppVersion`). Chart `version` tracks `appVersion` 1:1 |
 | `postgres` | 16.15-alpine (`docker-compose.yml`) |
 
 ## GitHub Actions (`.github/workflows/*.yml` — SHA-pinned, comment carries the tag)

--- a/.helm/allure-server/Chart.yaml
+++ b/.helm/allure-server/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: allure-server
 description: Allure Server application helm chart for Kubernetes
 type: application
-version: 3.0.0
+version: 3.0.1
 # Single source of the deployed image tag: values.yaml image.tag falls back to this.
-appVersion: 3.0.0
+appVersion: 3.0.1

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker run -d --name allure-server \
   -p 8080:8080 \
   -v "$PWD/allure-server-store:/allure:rw" \
   -v "$PWD/ext:/ext:rw" \
-  kochetkovma/allure-server:3.0.0
+  kochetkovma/allure-server:3.0.1
 ```
 
 The container runs as non-root uid/gid `1000` (`Dockerfile:35`, `Dockerfile:48`), so a host bind
@@ -615,8 +615,8 @@ services:
     build:
       context: .
       args:
-        APP_VERSION: "3.0.0"
-    image: kochetkovma/allure-server:3.0.0
+        APP_VERSION: "3.0.1"
+    image: kochetkovma/allure-server:3.0.1
     ports:
       - "8080:8080"
     volumes:
@@ -639,8 +639,8 @@ services:
     build:
       context: .
       args:
-        APP_VERSION: "3.0.0"
-    image: kochetkovma/allure-server:3.0.0
+        APP_VERSION: "3.0.1"
+    image: kochetkovma/allure-server:3.0.1
     ports:
       - "8080:8080"
     volumes:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,22 +19,22 @@ instead of the legacy `sha256-<digest>.sig` tag, so cosign 2.x reports `no signa
 images even though the signature is present and valid. If you see that error, upgrade the client
 before concluding anything about the image.
 
-Verify a tag before running it, replacing `3.0.0` with the version you pulled:
+Verify a tag before running it, replacing `3.0.1` with the version you pulled:
 
 ```bash
 cosign verify \
-  --certificate-identity "https://github.com/kochetkov-ma/allure-server/.github/workflows/release.yml@refs/tags/v3.0.0" \
+  --certificate-identity "https://github.com/kochetkov-ma/allure-server/.github/workflows/release.yml@refs/tags/v3.0.1" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  kochetkovma/allure-server:3.0.0
+  kochetkovma/allure-server:3.0.1
 ```
 
 The same image is published to GHCR and signed in the same run:
 
 ```bash
 cosign verify \
-  --certificate-identity "https://github.com/kochetkov-ma/allure-server/.github/workflows/release.yml@refs/tags/v3.0.0" \
+  --certificate-identity "https://github.com/kochetkov-ma/allure-server/.github/workflows/release.yml@refs/tags/v3.0.1" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  ghcr.io/kochetkov-ma/allure-server:3.0.0
+  ghcr.io/kochetkov-ma/allure-server:3.0.1
 ```
 
 The certificate identity is the tag being verified, so it changes with every version.

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.54.0'
 
     // https://docs.spring.io/spring-boot/docs/current/reference/html/dependency-versions.html
-    id 'org.springframework.boot' version '3.4.13'
+    id 'org.springframework.boot' version '3.5.16'
     id 'io.spring.dependency-management' version '1.1.7'
 
     id "org.openapi.generator" version '7.11.0'
@@ -19,21 +19,14 @@ plugins {
 apply from: './gradle/dependencies.gradle'
 apply from: './gradle/testing.gradle'
 
-// Spring Cloud release train (2024.0.x is the train that targets Spring Boot 3.4.x).
+// Spring Cloud release train (2025.0.x is the train that targets Spring Boot 3.5.x —
+// spring-cloud-starter-parent:2025.0.3 declares spring-boot-starter-parent 3.5.15).
 // Importing the BOM here means individual Spring Cloud starters in gradle/dependencies.gradle
 // MUST be declared without an explicit version.
-ext.springCloudVersion = '2024.0.3'
-// Byte Buddy 1.17.5+ is required for Java 25 class-file version 69 support.
-// Spring Boot 3.4.x BOM still pins 1.15.11 (supports Java 24 max), so we override.
-// See https://github.com/raphw/byte-buddy/releases (1.17.5 updated ASM to 9.8).
-ext.byteBuddyVersion = '1.17.5'
+ext.springCloudVersion = '2025.0.3'
 dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-    }
-    dependencies {
-        dependency "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
-        dependency "net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}"
     }
 }
 

--- a/docker-compose-h2.yml
+++ b/docker-compose-h2.yml
@@ -14,8 +14,8 @@ services:
       context: .
       args:
         # Baked into the jar name and reported by the app; keep in lockstep with the image tag.
-        APP_VERSION: "3.0.0"
-    image: kochetkovma/allure-server:3.0.0
+        APP_VERSION: "3.0.1"
+    image: kochetkovma/allure-server:3.0.1
     ports:
       # Container listens on 8080; the Dockerfile HEALTHCHECK also probes 8080, so change PORT
       # only together with the healthcheck.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       context: .
       args:
         # Baked into the jar name and reported by the app; keep in lockstep with the image tag.
-        APP_VERSION: "3.0.0"
-    image: kochetkovma/allure-server:3.0.0
+        APP_VERSION: "3.0.1"
+    image: kochetkovma/allure-server:3.0.1
     ports:
       # Container listens on 8080; the Dockerfile HEALTHCHECK also probes 8080, so change PORT
       # only together with the healthcheck.

--- a/docs/DOCKERHUB.md
+++ b/docs/DOCKERHUB.md
@@ -39,7 +39,7 @@ docker run -d --name allure-server \
   -p 8080:8080 \
   -v "$PWD/allure-server-store:/allure:rw" \
   -v "$PWD/ext:/ext:rw" \
-  kochetkovma/allure-server:3.0.0
+  kochetkovma/allure-server:3.0.1
 ```
 
 The container runs as non-root uid/gid `1000`, so a host bind mount must be owned by `1000:1000`
@@ -122,7 +122,7 @@ first start.
 ```yaml
 services:
   allure-server:
-    image: kochetkovma/allure-server:3.0.0
+    image: kochetkovma/allure-server:3.0.1
     ports:
       - "8080:8080"
     volumes:
@@ -139,7 +139,7 @@ difference from the H2 file:
 ```yaml
 services:
   allure-server:
-    image: kochetkovma/allure-server:3.0.0
+    image: kochetkovma/allure-server:3.0.1
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
Patch release 3.0.1. The first Trivy scan of the published 3.0.0 image found five CRITICAL CVEs, all in the application jar layer, none in the base image. This clears all five.

| CVE | Package | Before | After |
|---|---|---|---|
| CVE-2026-41293, CVE-2026-43512, CVE-2026-43515 | `tomcat-embed-core` | 10.1.50 | 10.1.55 |
| CVE-2026-22732 | `spring-security-web` | 6.4.13 | 6.5.11 |
| CVE-2025-14813 | `bcprov-jdk18on` | 1.78.1 | 1.80.2 |

Spring Boot 3.4.13 -> 3.5.16, Spring Cloud 2024.0.3 -> 2025.0.3. The pair was verified compatible: `spring-cloud-starter-parent:2025.0.3` declares `spring-boot-starter-parent:3.5.15`, and the next train, 2025.1.x, requires Boot 4.0. Boot 3.5 is also the first train that officially supports Java 25, which this project already targets, so this moves the toolchain onto supported ground. The `byteBuddyVersion` override is dropped because the new BOM pins 1.17.8.

No source files changed.

## Verification

- `./gradlew build`: 262 tests, 0 failures, 0 errors, 0 skipped, matching the 3.0.0 baseline exactly.
- `.claude/scripts/e2e-api.sh` against the built image: 30/30.
- Trivy, same filter and `--ignore-unfixed=false` as `security-scan.yml`, both images scanned with the same binary and database so the baseline is re-derived rather than quoted:

| Image | CRITICAL | HIGH | MEDIUM | Total |
|---|---|---|---|---|
| 3.0.0 | 5 | 32 | 48 | 85 |
| 3.0.1 | 0 | 13 | 27 | 40 |

- A read-only review of the Spring Security 6.4 -> 6.5 delta found no behaviour change here: the new `PathPattern` matcher path is opt-in and this app never opts in, `AuthorizationManager` and the CSRF and filter-order classes are byte-identical, and the Boot 3.5 OAuth2 auto-config split stays suppressed by this app own filter chain in both trains.
- The `oauth` profile has no test coverage, so it was verified by hand: the app starts, and `GET /oauth2/authorization/google` returns a 302 to the Google authorization endpoint, proving `oauth2Login` is registered under the new auto-config split.
- All three documented auth modes re-checked against `docs/COMPATIBILITY.md`: anonymous default, `basic.auth.enable=true` lockdown, and `X-API-Token`. No new breaking change.

## Not included

The remaining HIGH findings are led by the checked-in Allure plugin jars at 2.29.0. Clearing those needs a coordinated bump of the Allure core to 2.45.0, because the 2.45.0 plugin jars no longer ship their own `static/index.js` and dropping them onto the 2.39.0 generator would silently remove the Behaviors tab, the Packages tab and screen-diff rendering. That is a report-rendering change, not a patch, so it ships separately.